### PR TITLE
docker-machine uses --version

### DIFF
--- a/two1/sell/installer.py
+++ b/two1/sell/installer.py
@@ -143,7 +143,7 @@ class InstallerMac(InstallerBase):
 
         packages.append("Docker Machine")
         try:
-            subprocess.check_output(["docker-machine", "version"])
+            subprocess.check_output(["docker-machine", "--version"])
         except:
             installed.append(False)
         else:


### PR DESCRIPTION
`21 sell start ping` currently fails like this:
![screen shot 2016-06-12 at 12 50 07 pm](https://cloud.githubusercontent.com/assets/8891120/15988649/50065aae-309c-11e6-8018-cc2785465895.png)
This is because it uses `docker-machine version` which isn't a command. Using the correct command `docker-machine --version` fixes it:
![screen shot 2016-06-12 at 12 42 57 pm](https://cloud.githubusercontent.com/assets/8891120/15988640/d5f849de-309b-11e6-9019-383b8e871aeb.png)

