### PR TITLE
Flask_Decorator: Allow function args to be passed to pricing handler

### DIFF
--- a/two1/bitserv/flask/decorator.py
+++ b/two1/bitserv/flask/decorator.py
@@ -86,7 +86,7 @@ class Payment:
             def _fn(*fn_args, **fn_kwargs):
                 # Calculate resource cost
                 nonlocal price
-                _price = price(request) if callable(price) else price
+                _price = price(request, *fn_args, **fn_kwargs) if callable(price) else price
 
                 # Need better way to pass server url to payment methods (FIXME)
                 if 'server_url' not in kwargs:


### PR DESCRIPTION
During implementation of a pricing handler, I wanted the URL variable to be accessible.  This change allows the flask payment required function to also pass the fn_args, fn_kwargs to the pricing handler so all variables are accessible there as well.

Here is an example of what I wanted to be able to do.  I wanted to access the "val" url variable defined in the app.route() definition.
```
def get_price_for_url(request, val):
  return val * 100

@app.route('/buy/<int:val>')
@payment.required(get_price_for_url)
def buy(val):
  if val > 100
    return json.dumps({"success": True})
  else
    return json.dumps({"success": False})
```