### PR TITLE
Bitrequests: Fixed price header to have a string type instead of int …

### DIFF
--- a/two1/bitrequests/bitrequests.py
+++ b/two1/bitrequests/bitrequests.py
@@ -321,7 +321,7 @@ class OnChainRequests(BitRequests):
         return {
             'Bitcoin-Transaction': onchain_payment,
             'Return-Wallet-Address': return_address,
-            OnChainRequests.HTTP_BITCOIN_PRICE: price,
+            OnChainRequests.HTTP_BITCOIN_PRICE: str(price),
             OnChainRequests.HTTP_PAYER_21USERNAME: urllib.parse.quote(self.username) if self.username else None
         }
 


### PR DESCRIPTION
…due to change in requests lib

I ran into a problem with onchain buy:

```
$ 21 buy ... --payment-method onchain ...
May be using unconfirmed inputs to complete transaction.
Error: Header value 100000 must be of type str or bytes, not <class 'int'>
```

Found that the requests library made a change to fail on non string or bytes headers:
https://github.com/kennethreitz/requests/issues/3477