### PR TITLE
Use correct key field in HDPrivateKey.__int__

### DIFF
--- a/two1/bitcoin/crypto.py
+++ b/two1/bitcoin/crypto.py
@@ -1476,7 +1476,7 @@ class HDPrivateKey(HDKey, PrivateKeyBase):
         return self.public_key.hash160()
 
     def __int__(self):
-        return int(self.key)
+        return int(self._key)
 
 
 class HDPublicKey(HDKey, PublicKeyBase):


### PR DESCRIPTION
HDPrivateKey does not have `key` field, it should be `_key` instead.